### PR TITLE
Expand selector and tokenizer test coverage

### DIFF
--- a/internal/selector/matcher_test.go
+++ b/internal/selector/matcher_test.go
@@ -1,0 +1,76 @@
+package selector
+
+import (
+	"testing"
+
+	"github.com/MuxN4/gocheerio/internal/dom"
+	"golang.org/x/net/html"
+)
+
+func TestMatchesAttribute(t *testing.T) {
+	testsCases := []struct {
+		name     string
+		node     *dom.Node
+		attr     *AttributeSelector
+		expected bool
+	}{
+		{
+			name:     "Attribute exists",
+			node:     &dom.Node{Node: &html.Node{Type: html.ElementNode, Data: "div", Attr: []html.Attribute{{Key: "id", Val: "test"}}}},
+			attr:     &AttributeSelector{Key: "id", Value: "", Operator: ""},
+			expected: true,
+		},
+		{
+			name:     "Attribute equals",
+			node:     &dom.Node{Node: &html.Node{Type: html.ElementNode, Data: "div", Attr: []html.Attribute{{Key: "id", Val: "test"}}}},
+			attr:     &AttributeSelector{Key: "id", Value: "test", Operator: "="},
+			expected: true,
+		},
+		{
+			name:     "Attribute not equals",
+			node:     &dom.Node{Node: &html.Node{Type: html.ElementNode, Data: "div", Attr: []html.Attribute{{Key: "id", Val: "test"}}}},
+			attr:     &AttributeSelector{Key: "id", Value: "not-test", Operator: "="},
+			expected: false,
+		},
+		{
+			name:     "Attribute contains word",
+			node:     &dom.Node{Node: &html.Node{Type: html.ElementNode, Data: "div", Attr: []html.Attribute{{Key: "class", Val: "foo bar"}}}},
+			attr:     &AttributeSelector{Key: "class", Value: "foo", Operator: "~="},
+			expected: true,
+		},
+		{
+			name:     "Attribute starts with",
+			node:     &dom.Node{Node: &html.Node{Type: html.ElementNode, Data: "div", Attr: []html.Attribute{{Key: "class", Val: "foo bar"}}}},
+			attr:     &AttributeSelector{Key: "class", Value: "foo", Operator: "^="},
+			expected: true,
+		},
+		{
+			name:     "Attribute ends with",
+			node:     &dom.Node{Node: &html.Node{Type: html.ElementNode, Data: "div", Attr: []html.Attribute{{Key: "class", Val: "foo bar"}}}},
+			attr:     &AttributeSelector{Key: "class", Value: "bar", Operator: "$="},
+			expected: true,
+		},
+		{
+			name:     "Attribute contains",
+			node:     &dom.Node{Node: &html.Node{Type: html.ElementNode, Data: "div", Attr: []html.Attribute{{Key: "class", Val: "foo bar"}}}},
+			attr:     &AttributeSelector{Key: "class", Value: "oo b", Operator: "*="},
+			expected: true,
+		},
+		{
+			name:     "Attribute pipe equals",
+			node:     &dom.Node{Node: &html.Node{Type: html.ElementNode, Data: "div", Attr: []html.Attribute{{Key: "lang", Val: "en-US"}}}},
+			attr:     &AttributeSelector{Key: "lang", Value: "en", Operator: "|="},
+			expected: true,
+		},
+	}
+
+	for _, tt := range testsCases {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := &Matcher{}
+			result := matcher.matchesAttribute(tt.node, tt.attr)
+			if result != tt.expected {
+				t.Errorf("matchesAttribute() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/selector/matcher_test.go
+++ b/internal/selector/matcher_test.go
@@ -62,6 +62,16 @@ func TestMatchesAttribute(t *testing.T) {
 			attr:     &AttributeSelector{Key: "lang", Value: "en", Operator: "|="},
 			expected: true,
 		},
+		{
+			name: "Unknown operator",
+			node: &dom.Node{Node: &html.Node{Type: html.ElementNode, Data: "div", Attr: []html.Attribute{{Key: "data-test", Val: "value"}}}},
+			attr: &AttributeSelector{
+				Key:      "data-test",
+				Value:    "value",
+				Operator: "unknown",
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range testsCases {

--- a/internal/selector/selector_test.go
+++ b/internal/selector/selector_test.go
@@ -86,6 +86,32 @@ func TestSelectorMatching(t *testing.T) {
 			selector: "div.test#unique",
 			expected: map[string]int{"div": 1},
 		},
+
+		// negative test cases
+		{
+			name:     "Non element node",
+			html:     "<!-- This is a comment -->",
+			selector: "p",
+			expected: map[string]int{},
+		},
+		{
+			name:     "Non-Matching ID Selector",
+			html:     "<div id='not-test'><p>Content</p></div>",
+			selector: "#test",
+			expected: map[string]int{},
+		},
+		{
+			name:     "Non-Matching Class Selector",
+			html:     "<div class='not-test'><p>Content</p></div>",
+			selector: ".test",
+			expected: map[string]int{},
+		},
+		{
+			name:     "Non-Matching Attribute Selector",
+			html:     "<div data-test='not-value'><p data-test='other'>Content</p></div>",
+			selector: "[data-test='value']",
+			expected: map[string]int{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/selector/tokenizer_test.go
+++ b/internal/selector/tokenizer_test.go
@@ -30,6 +30,14 @@ func TestTokenizer(t *testing.T) {
 				{Type: TokenTypeTag, Value: "p"},
 			},
 		},
+		// token type Invalid test
+		{
+			input: "div@",
+			expected: []Token{
+				{Type: TokenTypeTag, Value: "div"},
+				{Type: TokenTypeInvalid, Value: ""},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Hello!

During the holidays, I reviewed the codebase and wrote some small test cases. As the issue only mentions testing, this PR contains only tests.

The issue with selectors is that combinators are not working at all, so there are no test cases for them here. I think we should open an issue on relational selectors to discuss this further.

This partially solves #4.

Adding these tests makes the tokenizer 100% covered.